### PR TITLE
Respect user-defined cp route while binding entries

### DIFF
--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -12,7 +12,8 @@ class RouteServiceProvider extends StatamicServiceProvider
     protected function bindEntries()
     {
         // On Eloquenty routes we bind entry with Eloquenty Entry class
-        if (starts_with(request()->path(), 'cp/eloquenty')) {
+        $cpRoute = config('statamic.cp.route', 'cp');
+        if (starts_with(request()->path(), "$cpRoute/eloquenty")) {
             Route::bind('entry', function ($handle, $route) {
                 $eloquentyEntry = $this->app[EntryRepository::class];
 


### PR DESCRIPTION
This fixes editing eloquenty entries when using a custom cp route like
`/admin/eloquenty/collections/...`
_instead of_
`/cp/eloquenty/collections/...`