### PR TITLE
Fix for issue with multi-site on Statamic v3.3.x (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes will be documented in this file.
 
+## 1.1.6 - 2022-03-18
+
+- Updated composer.json for Laravel 9 support
+
 ## 1.1.5 - 2022-02-05
 
 - Fixed PHP 7.4 support (thanks tomhelmer)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "laravel/framework": "^7.0 || ^8.0",
+        "laravel/framework": "^7.0 || ^8.0 || ^9.0",
         "statamic/cms": "^3.0"
     }
 }

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -64,11 +64,6 @@ class Entry extends FileEntry
         return $this;
     }
 
-    public function lastModified()
-    {
-        return $this->model->updated_at;
-    }
-
     public function origin($origin = null)
     {
         if (func_num_args() > 0) {


### PR DESCRIPTION
* Respect user-defined cp route while binding entries in RouteServiceProvider

This fixes editing eloquenty entries when using a custom cp route like
/admin/eloquenty/collections/...
instead of
/cp/eloquenty/collections/...

* (wip) Laravel 9 support (#10)

* Update CHANGELOG.md

* Fix multi-site on Statamic v3.3.x

Let Statamic handle the lastModified() result -> Statamic 3.3 will return a carbon instance instead of returning the timestamp.
Tested on Statamic 3.3 and Statamic 3.2

Co-authored-by: Nikolas Fragkos <nikolasfragkos@gmail.com>