### PR TITLE
Bug: Asset actions

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -32,7 +32,7 @@ class Entry extends FileEntry
             ->published($model->published)
             ->model($model);
 
-        if ($model->date && $entry->collection()->dated()) {
+        if ($model->date && $entry->collection()?->dated()) {
             $entry->date($model->date);
         }
 


### PR DESCRIPTION
When we move or delete assets directly from the CP < Assets section, Statamic attempts to update all asset references for that asset (`UpdateAssetReferences`).

If the collection is deleted and does not exist, but entries related to that collection still exist in the database, it breaks.

 